### PR TITLE
Removed frame around cards when swiped.

### DIFF
--- a/src/WeeklyXamarin.Mobile/WeeklyXamarin.Mobile/Views/ArticleDataTemplate.xaml
+++ b/src/WeeklyXamarin.Mobile/WeeklyXamarin.Mobile/Views/ArticleDataTemplate.xaml
@@ -61,7 +61,7 @@
             </SwipeItemView>
         </SwipeItems>
     </SwipeView.RightItems>
-    <ContentView BackgroundColor="{StaticResource WhiteLight}">
+    <ContentView >
         <rv:MaterialFrame
             Margin="{StaticResource CardMargin}"
             Padding="0"


### PR DESCRIPTION
When card swiped, there is some frame which cuts some of action buttons.
![Simulator Screen Shot - iPhone 12 - 2021-05-12 at 17 55 47](https://user-images.githubusercontent.com/30383473/117979672-9abe9600-b34c-11eb-821f-4c68e1e32afa.png)
This PR removes the frame. 
Here is the result.
![Simulator Screen Shot - iPhone 12 - 2021-05-12 at 17 55 04](https://user-images.githubusercontent.com/30383473/117979746-ab6f0c00-b34c-11eb-894d-bb18ec40bb04.png)
