### PR TITLE
fixes/FirstLoad-BlankListLinker

### DIFF
--- a/src/WeeklyXamarin.Mobile/WeeklyXamarin.Core/ViewModels/EditionsViewModel.cs
+++ b/src/WeeklyXamarin.Mobile/WeeklyXamarin.Core/ViewModels/EditionsViewModel.cs
@@ -27,6 +27,7 @@ namespace WeeklyXamarin.Core.ViewModels
             LoadEditionsCommand = new AsyncCommand(ExecuteLoadEditionsCommand);
             OpenEditionCommand = new AsyncCommand<Edition>(OpenEdition);
             this.dataStore = dataStore;
+            ExecuteLoadEditionsCommand();
         }
 
         private async Task OpenEdition(Edition edition)


### PR DESCRIPTION
* Fixed issue with #36 where the Editions list was not displaying the first time the app is launched

**Testing**
---------
* Tested with iOS simulator before changes with Linker set to Link All and had a blank page
* Tested with iOS simulator after changes with Linker set to Link All and didn't have a blank page anymore