### PR TITLE
Preserving MvvmHelpers from Linker

### DIFF
--- a/src/WeeklyXamarin.Mobile/WeeklyXamarin.Mobile.Android/Properties/linker.xml
+++ b/src/WeeklyXamarin.Mobile/WeeklyXamarin.Mobile.Android/Properties/linker.xml
@@ -66,4 +66,7 @@
   <assembly fullname="Microsoft.Extensions.Logging.Configuration">
     <type fullname="*"/>
   </assembly>
+  <assembly fullname="MvvmHelpers">
+    <type fullname="*" />
+  </assembly>
 </linker>

--- a/src/WeeklyXamarin.Mobile/WeeklyXamarin.Mobile.iOS/Properties/linker.xml
+++ b/src/WeeklyXamarin.Mobile/WeeklyXamarin.Mobile.iOS/Properties/linker.xml
@@ -60,4 +60,7 @@
   <assembly fullname="Microsoft.Extensions.Logging.Configuration">
     <type fullname="*"/>
   </assembly>
+  <assembly fullname="MvvmHelpers">
+    <type fullname="*" />
+  </assembly>
 </linker>


### PR DESCRIPTION
As discussed in #36, using the IsBusy property from MvvmHelpers.BaseViewModel as the bound property for IsRefreshing appears to prevent the RefreshView's IsRefreshing BindableProperty's Change event from triggering when the Linker is on.

By not triggering the Change event, the Command is not invoked and the Editions are not loaded.

## Changes made

- Added MvvmHelpers to Linker.xml

## Addresses issue

- #36 "On first load, editions don't display"

## Tests

- Manually tested in Debug (Device mode) for iOS
- Manually tested in Release config for iOS & Android