### PR TITLE
Added persistence of unbookmarked articles until bookmark list refresh

### DIFF
--- a/src/WeeklyXamarin.Mobile/WeeklyXamarin.Core/Models/SavedArticleThing.cs
+++ b/src/WeeklyXamarin.Mobile/WeeklyXamarin.Core/Models/SavedArticleThing.cs
@@ -15,6 +15,13 @@ namespace WeeklyXamarin.Core.Models
                 Articles.Add(articleToSave);
         }
 
+        public void Insert(int index, Article articleToSave)
+        {
+            var article = Articles.FirstOrDefault(a => a.Id == articleToSave.Id);
+            if (article == null)
+                Articles.Insert(index, articleToSave);
+        }
+
         public void Remove(Article articleToRemove)
         {
             var article = Articles.FirstOrDefault(a => a.Id == articleToRemove.Id);

--- a/src/WeeklyXamarin.Mobile/WeeklyXamarin.Core/Services/GithubDataStore.cs
+++ b/src/WeeklyXamarin.Mobile/WeeklyXamarin.Core/Services/GithubDataStore.cs
@@ -179,6 +179,14 @@ namespace WeeklyXamarin.Core.Services
 
             _barrel.Add(key: Constants.BarrelNames.SavedArticles, data: savedArticleList, expireIn: TimeSpan.FromDays(999));
         }
+        public void BookmarkArticleAtIndex(Article articleToSave, int index)
+        {
+            var savedArticleList = GetSavedArticles(false);
+            articleToSave.IsSaved = true;
+            savedArticleList.Insert(index, articleToSave);
+
+            _barrel.Add(key: Constants.BarrelNames.SavedArticles, data: savedArticleList, expireIn: TimeSpan.FromDays(999));
+        }
         public void UnbookmarkArticle(Article articleToRemove)
         {
             var savedArticleList = GetSavedArticles(false);

--- a/src/WeeklyXamarin.Mobile/WeeklyXamarin.Core/Services/IDataStore.cs
+++ b/src/WeeklyXamarin.Mobile/WeeklyXamarin.Core/Services/IDataStore.cs
@@ -15,6 +15,7 @@ namespace WeeklyXamarin.Core.Services
         Task<Article> GetArticleAsync(string editionId, string articleId);
         SavedArticleThing GetSavedArticles(bool forceRefresh);
         void BookmarkArticle(Article articleToSave);
+        void BookmarkArticleAtIndex(Article articleToSave, int index);
         void UnbookmarkArticle(Article articleToRemove);
         IAsyncEnumerable<Article> GetArticleFromSearchAsync(string searchText, CancellationToken token, bool forceRefresh = false);
         Task<bool> PreloadNextEdition();


### PR DESCRIPTION
If an article is unbookmarked from the bookmarked articles list, it will stay on the list until the user navigates away.

If it is bookmarked again, it is put back at the exact same spot.