### PR TITLE
Smabuk/theming

### DIFF
--- a/src/WeeklyXamarin.Mobile/WeeklyXamarin.Blazor/Client/App.razor
+++ b/src/WeeklyXamarin.Mobile/WeeklyXamarin.Blazor/Client/App.razor
@@ -1,7 +1,3 @@
-@using MonkeyCache;
-@inject IBarrel Barrel;
-@inject IJSRuntime jSRuntime;
-
 <Router AppAssembly="@typeof(Program).Assembly" PreferExactMatches="@true">
     <Found Context="routeData">
         <RouteView RouteData="@routeData" DefaultLayout="@typeof(MainLayout)" />
@@ -12,12 +8,3 @@
         </LayoutView>
     </NotFound>
 </Router>
-
-@code { 
-    protected override async Task OnInitializedAsync()
-    {
-        await  base.OnInitializedAsync();
-        var storedTheme = Barrel.Get<bool>("is-dark-theme");
-        await jSRuntime.InvokeVoidAsync("switchTheme", storedTheme);
-    }
-}

--- a/src/WeeklyXamarin.Mobile/WeeklyXamarin.Blazor/Client/Components/ThemeSwitch.razor
+++ b/src/WeeklyXamarin.Mobile/WeeklyXamarin.Blazor/Client/Components/ThemeSwitch.razor
@@ -2,40 +2,38 @@
 @inject IBarrel Barrel;
 @inject IJSRuntime jSRuntime;
 
-<NavLink class="nav-link" @onclick="@ThemeSwitchChanged">
-    <span title="@($"Change theme")" class="oi @IconClass" aria-hidden="true"></span><span class="nav-text">Theme</span>
-</NavLink>
+<span title="@TitleText" class="oi @IconClass" aria-hidden="true" @onclick="@ThemeSwitchChanged"> Theme</span>
+
 @code {
     string Theme;
     string NextTheme => Theme switch
     {
-        "System" => "Dark",
-        "Dark" => "Light",
-        "Light" => "System"
+        "system" => "dark",
+        "dark" => "light",
+        "light" => "system",
+        _ => "dark"
     };
 
     string IconClass => NextTheme switch
     {
-        "System" => "oi-cloudy",
-        "Dark" => "oi-moon",
-        "Light" => "oi-sun"
+        "system" => "oi-cloudy",
+        "dark" => "oi-moon",
+        "light" => "oi-sun",
+        _ => "oi-moon"
     };
 
+    string TitleText => $"Change from {Theme ?? "system"} to {NextTheme} theme";
 
     public async Task ThemeSwitchChanged()
     {
         Theme = NextTheme;
-
-        Barrel.Add("theme", Theme, default);
         await jSRuntime.InvokeVoidAsync("switchTheme", Theme);
     }
 
     protected override async Task OnInitializedAsync()
     {
-        await base.OnInitializedAsync();
         Theme = Barrel.Get<string>("theme");
-        Theme = string.IsNullOrWhiteSpace(Theme) ? "System" : Theme;
-        await jSRuntime.InvokeVoidAsync("switchTheme", Theme);
-
+        Theme = string.IsNullOrWhiteSpace(Theme) ? "system" : Theme;
+        await jSRuntime.InvokeVoidAsync("switchTheme");
     }
 }

--- a/src/WeeklyXamarin.Mobile/WeeklyXamarin.Blazor/Client/Components/ThemeSwitch.razor
+++ b/src/WeeklyXamarin.Mobile/WeeklyXamarin.Blazor/Client/Components/ThemeSwitch.razor
@@ -2,7 +2,7 @@
 @inject IBarrel Barrel;
 @inject IJSRuntime jSRuntime;
 
-<span title="@TitleText" class="oi @IconClass" aria-hidden="true" @onclick="@ThemeSwitchChanged"> Theme</span>
+<span @onclick="@ThemeSwitchChanged"><span title="@TitleText" class="oi @IconClass" aria-hidden="true"></span> Theme</span>
 
 @code {
     string Theme;
@@ -22,7 +22,7 @@
         _ => "oi-moon"
     };
 
-    string TitleText => $"Change from {Theme ?? "system"} to {NextTheme} theme";
+    string TitleText => $"Change from {Theme} to {NextTheme} theme";
 
     public async Task ThemeSwitchChanged()
     {
@@ -32,7 +32,7 @@
 
     protected override async Task OnInitializedAsync()
     {
-        Theme = Barrel.Get<string>("theme");
+        Theme = Barrel.Get<string>("theme").ToLowerInvariant();
         Theme = string.IsNullOrWhiteSpace(Theme) ? "system" : Theme;
         await jSRuntime.InvokeVoidAsync("switchTheme");
     }

--- a/src/WeeklyXamarin.Mobile/WeeklyXamarin.Blazor/Client/Shared/NavMenu.razor
+++ b/src/WeeklyXamarin.Mobile/WeeklyXamarin.Blazor/Client/Shared/NavMenu.razor
@@ -17,7 +17,9 @@
         <NavLink class="nav-link" href="About">
             <span class="oi oi-heart" aria-hidden="true"></span><span class="nav-text">About</span>
         </NavLink>
-        <ThemeSwitch></ThemeSwitch>
+        <NavLink class="nav-link">
+            <ThemeSwitch></ThemeSwitch>
+        </NavLink>
         
     </div>
 </div>

--- a/src/WeeklyXamarin.Mobile/WeeklyXamarin.Blazor/Client/Shared/NavMenu.razor
+++ b/src/WeeklyXamarin.Mobile/WeeklyXamarin.Blazor/Client/Shared/NavMenu.razor
@@ -18,7 +18,7 @@
             <span class="oi oi-heart" aria-hidden="true"></span><span class="nav-text">About</span>
         </NavLink>
         <NavLink class="nav-link">
-            <ThemeSwitch></ThemeSwitch>
+            <ThemeSwitch />
         </NavLink>
         
     </div>

--- a/src/WeeklyXamarin.Mobile/WeeklyXamarin.Blazor/Client/Shared/NavMenu.razor.css
+++ b/src/WeeklyXamarin.Mobile/WeeklyXamarin.Blazor/Client/Shared/NavMenu.razor.css
@@ -11,7 +11,12 @@
     font-size: 1.1rem;
 }
 
-
+.oi {
+    font-size: 1.1rem;
+    vertical-align: text-top;
+    top: -2px;
+    margin-right: 5px;
+}
 
 .nav-item {
     font-size: 0.9rem;

--- a/src/WeeklyXamarin.Mobile/WeeklyXamarin.Blazor/Client/wwwroot/css/app.css
+++ b/src/WeeklyXamarin.Mobile/WeeklyXamarin.Blazor/Client/wwwroot/css/app.css
@@ -1,4 +1,5 @@
 ﻿@import url('open-iconic/font/css/open-iconic-bootstrap.min.css');
+@import url('themes.css');
 
 html, body {
     font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif;
@@ -8,19 +9,6 @@ html, body {
 a, .btn-link, a:not([href]):not([tabindex]) {
     color: var(--white);
 }
-
-.oi {
-    font-size: 1.1rem;
-    vertical-align: text-top;
-    top: -2px;
-    margin-right: 5px;
-}
-
-    .link-item {
-        color: var(--link);
-        display: block;
-        font-size: 14pt;
-    }
 
 .viewer {
     margin: 10px 20px;
@@ -93,48 +81,6 @@ p {
 .category-xamarin-forms
 {
     background-color: red;
-}
-
-:root {
-    --min-desktop-width: 641px;
-    --min-desktop-width: 641px;
-    --SkyBlueLight: #3598DB;
-    --YellowDark: #FFA800;
-    --TealLight: #3A6F81;
-    --PinkLight: #F47CC3;
-    --RedLight: #E84C3D;
-    --PowderBlueDark: #99AAD5;
-    --WatermelonLight: #EF727A;
-    --GreenLight: #2DCC70;
-    --MagentaLight: #9B58B5;
-    --LimeLight: #A5C63B;
-    --OrangeLight: #E77E23;
-    --BlueLight: #5165A2;
-    --white: #ffffff;
-    --card-background: #ffffff;
-    --text: #2B2B2B;
-    --link: var(--text);
-    --background: #ECF0F1;
-}
-
-[data-theme="dark"] {
-    --SkyBlueLight: #3598DB;
-    --YellowDark: #FFA800;
-    --TealLight: #3A6F81;
-    --PinkLight: #F47CC3;
-    --RedLight: #E84C3D;
-    --PowderBlueDark: #99AAD5;
-    --WatermelonLight: #EF727A;
-    --GreenLight: #2DCC70;
-    --MagentaLight: #9B58B5;
-    --LimeLight: #A5C63B;
-    --OrangeLight: #E77E23;
-    --BlueLight: #5165A2;
-    --card-background: #232124;
-    --white: #ffffff;
-    --text: #BEC3C7;
-    --link: var(--text);
-    --background: #151515;
 }
 
 .content {

--- a/src/WeeklyXamarin.Mobile/WeeklyXamarin.Blazor/Client/wwwroot/css/themes.css
+++ b/src/WeeklyXamarin.Mobile/WeeklyXamarin.Blazor/Client/wwwroot/css/themes.css
@@ -1,0 +1,83 @@
+﻿:root {
+    --min-desktop-width: 641px;
+    --min-desktop-width: 641px;
+    --SkyBlueLight: #3598DB;
+    --YellowDark: #FFA800;
+    --TealLight: #3A6F81;
+    --PinkLight: #F47CC3;
+    --RedLight: #E84C3D;
+    --PowderBlueDark: #99AAD5;
+    --WatermelonLight: #EF727A;
+    --GreenLight: #2DCC70;
+    --MagentaLight: #9B58B5;
+    --LimeLight: #A5C63B;
+    --OrangeLight: #E77E23;
+    --BlueLight: #5165A2;
+    --white: #ffffff;
+    --card-background: #ffffff;
+    --text: #2B2B2B;
+    --link: var(--text);
+    --background: #ECF0F1;
+}
+
+@media (prefers-color-scheme: dark) {
+    :root {
+    --SkyBlueLight: #3598DB;
+    --YellowDark: #FFA800;
+    --TealLight: #3A6F81;
+    --PinkLight: #F47CC3;
+    --RedLight: #E84C3D;
+    --PowderBlueDark: #99AAD5;
+    --WatermelonLight: #EF727A;
+    --GreenLight: #2DCC70;
+    --MagentaLight: #9B58B5;
+    --LimeLight: #A5C63B;
+    --OrangeLight: #E77E23;
+    --BlueLight: #5165A2;
+    --card-background: #232124;
+    --white: #ffffff;
+    --text: #BEC3C7;
+    --link: var(--text);
+    --background: #151515;
+    }
+}
+
+[data-theme="dark"] {
+    --SkyBlueLight: #3598DB;
+    --YellowDark: #FFA800;
+    --TealLight: #3A6F81;
+    --PinkLight: #F47CC3;
+    --RedLight: #E84C3D;
+    --PowderBlueDark: #99AAD5;
+    --WatermelonLight: #EF727A;
+    --GreenLight: #2DCC70;
+    --MagentaLight: #9B58B5;
+    --LimeLight: #A5C63B;
+    --OrangeLight: #E77E23;
+    --BlueLight: #5165A2;
+    --card-background: #232124;
+    --white: #ffffff;
+    --text: #BEC3C7;
+    --link: var(--text);
+    --background: #151515;
+}
+
+[data-theme="light"] {
+    --SkyBlueLight: #3598DB;
+    --YellowDark: #FFA800;
+    --TealLight: #3A6F81;
+    --PinkLight: #F47CC3;
+    --RedLight: #E84C3D;
+    --PowderBlueDark: #99AAD5;
+    --WatermelonLight: #EF727A;
+    --GreenLight: #2DCC70;
+    --MagentaLight: #9B58B5;
+    --LimeLight: #A5C63B;
+    --OrangeLight: #E77E23;
+    --BlueLight: #5165A2;
+    --white: #ffffff;
+    --card-background: #ffffff;
+    --text: #2B2B2B;
+    --link: var(--text);
+    --background: #ECF0F1;
+}

--- a/src/WeeklyXamarin.Mobile/WeeklyXamarin.Blazor/Client/wwwroot/index.html
+++ b/src/WeeklyXamarin.Mobile/WeeklyXamarin.Blazor/Client/wwwroot/index.html
@@ -4,7 +4,7 @@
 <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
-    <!--<base href="/" />-->
+    <base href="/" />
     <base href="/WeeklyXamarin.mobile/" />
     <title>Weekly Xamarin</title>
     <link href="css/bootstrap/bootstrap.min.css" rel="stylesheet" />

--- a/src/WeeklyXamarin.Mobile/WeeklyXamarin.Blazor/Client/wwwroot/scripts/DarkTheme.js
+++ b/src/WeeklyXamarin.Mobile/WeeklyXamarin.Blazor/Client/wwwroot/scripts/DarkTheme.js
@@ -1,27 +1,19 @@
-﻿var isSystemDark = window.matchMedia('(prefers-color-scheme: dark)');//Is syst
+﻿function switchTheme(theme) {
 
-function switchTheme(theme) {
-    var themeInBarrel = localStorage.getItem('theme');
-    var isThemeSystem = themeInBarrel != null && themeInBarrel.includes("System");
+    const currentTheme = localStorage.getItem('theme') ? localStorage.getItem('theme') : null;
+    theme = theme ? theme : currentTheme;
 
-    if (theme === "System") {
-        isSystemDark.addEventListener('change', OSChanged);
-        theme = isSystemDark.matches ? "Dark" : "Light";
-    }
-    else if (!isThemeSystem) {
-        isSystemDark.removeEventListener('change', OSChanged);
-    }
-
-    if (theme === "Dark") {
+    if (theme == 'dark') {
         document.documentElement.setAttribute('data-theme', 'dark');
+        localStorage.setItem('theme', 'dark');
+    }
+    else if (theme == 'light') {
+        document.documentElement.setAttribute('data-theme', 'light');
+        localStorage.setItem('theme', 'light');
     }
     else {
-        document.documentElement.setAttribute('data-theme', 'light');
+        document.documentElement.removeAttribute('data-theme');
     }
-}
 
-function OSChanged(e) {
-    var newTheme = isSystemDark.matches ? "Dark" : "Light";
-    switchTheme(newTheme);
 }
 


### PR DESCRIPTION
# What this does

- Reverts App.cs and NavMenu.razor.css back to their templates
- Uses lower case for the theme names rather than mixed which can get confusing and looks more natural in the html
- Uses a media query to handle system preferences
- The html data-theme attribute switches between "dark", "light" and not being set

# Down sides

For ease of creating this I've just duplicated the values for "light" and "dark" but these could easily be derived from a master set of values

# Not related
I had to put the base line back into the index.html to get this to run on my machine
