### PR TITLE
Display version with build date/time

### DIFF
--- a/src/WeeklyXamarin.Mobile/WeeklyXamarin.Blazor/Client/Pages/AboutPage.razor
+++ b/src/WeeklyXamarin.Mobile/WeeklyXamarin.Blazor/Client/Pages/AboutPage.razor
@@ -34,6 +34,8 @@
     </div>
 </Frame>
 
+<footer>Version: @Program.ProductVersion</footer>
+
 @code {
 
 }

--- a/src/WeeklyXamarin.Mobile/WeeklyXamarin.Blazor/Client/Program.cs
+++ b/src/WeeklyXamarin.Mobile/WeeklyXamarin.Blazor/Client/Program.cs
@@ -8,6 +8,7 @@ using MonkeyCache;
 using System;
 using System.Collections.Generic;
 using System.Net.Http;
+using System.Reflection;
 using System.Text;
 using System.Threading.Tasks;
 using WeeklyXamarin.Blazor.Client.Services;
@@ -46,5 +47,12 @@ namespace WeeklyXamarin.Blazor.Client
 
             await builder.Build().RunAsync();
         }
+
+        public static Version Version { get; set; } = typeof(Program).Assembly
+                        .GetName().Version ?? new();
+        public static string ProductVersion { get; set; } = typeof(Program).Assembly
+                                .GetCustomAttribute<AssemblyInformationalVersionAttribute>()?
+                                .InformationalVersion ?? "";
+
     }
 }

--- a/src/WeeklyXamarin.Mobile/WeeklyXamarin.Blazor/Client/WeeklyXamarin.Blazor.Client.csproj
+++ b/src/WeeklyXamarin.Mobile/WeeklyXamarin.Blazor/Client/WeeklyXamarin.Blazor.Client.csproj
@@ -6,6 +6,10 @@
     <ServiceWorkerAssetsManifest>service-worker-assets.js</ServiceWorkerAssetsManifest>
   </PropertyGroup>
 
+  <PropertyGroup>
+    <VersionSuffix>$([System.DateTime]::get_Now().get_Year())$([System.DateTime]::get_Now().get_Month().ToString("D2"))$([System.DateTime]::get_Now().get_Day().ToString("D2"))-$([System.DateTime]::get_Now().get_Hour().ToString("D2"))$([System.DateTime]::get_Now().get_Minute().ToString("D2"))</VersionSuffix>
+  </PropertyGroup>
+
   <ItemGroup>
     <PackageReference Include="Blazored.LocalStorage" Version="4.1.5" />
     <PackageReference Include="MatBlazor" Version="2.8.0" />

--- a/src/WeeklyXamarin.Mobile/WeeklyXamarin.Blazor/Server/Program.cs
+++ b/src/WeeklyXamarin.Mobile/WeeklyXamarin.Blazor/Server/Program.cs
@@ -5,6 +5,7 @@ using Microsoft.Extensions.Logging;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Reflection;
 using System.Threading.Tasks;
 
 namespace WeeklyXamarin.Blazor.Server
@@ -22,5 +23,12 @@ namespace WeeklyXamarin.Blazor.Server
                 {
                     webBuilder.UseStartup<Startup>();
                 });
+
+        public static Version Version { get; set; } = typeof(Program).Assembly
+                        .GetName().Version ?? new();
+        public static string ProductVersion { get; set; } = typeof(Program).Assembly
+                                .GetCustomAttribute<AssemblyInformationalVersionAttribute>()?
+                                .InformationalVersion ?? "";
+
     }
 }

--- a/src/WeeklyXamarin.Mobile/WeeklyXamarin.Blazor/Server/WeeklyXamarin.Blazor.Server.csproj
+++ b/src/WeeklyXamarin.Mobile/WeeklyXamarin.Blazor/Server/WeeklyXamarin.Blazor.Server.csproj
@@ -5,6 +5,10 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
+  <PropertyGroup>
+    <VersionSuffix>$([System.DateTime]::get_Now().get_Year())$([System.DateTime]::get_Now().get_Month().ToString("D2"))$([System.DateTime]::get_Now().get_Day().ToString("D2"))-$([System.DateTime]::get_Now().get_Hour().ToString("D2"))$([System.DateTime]::get_Now().get_Minute().ToString("D2"))</VersionSuffix>
+  </PropertyGroup>
+
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="5.0.10" />
   </ItemGroup>


### PR DESCRIPTION
# What it does

- Exposes the version numbers on the Program object for ease of access
- Displays the version of the assembly, complete with build date/time, in the About page

## Background

There are a few ways that this can be achieved, but this is the simplified version I'm using for Blazor projects.

I would normally include a full code block in the csproj a bit like this

```
  <PropertyGroup>
    <Authors>Simon Brookes</Authors>
    <Company>Simon Brookes</Company>
    <Copyright>Copyright © Simon Brookes</Copyright>
    <Description></Description>
    <VersionPrefix>0.8.20</VersionPrefix>
    <VersionSuffix Condition=" '$(ComputerName)' != '' ">$(ComputerName)-$([System.DateTime]::get_Now().get_Year())$([System.DateTime]::get_Now().get_Month().ToString("D2"))$([System.DateTime]::get_Now().get_Day().ToString("D2"))-$([System.DateTime]::get_Now().get_Hour().ToString("D2"))$([System.DateTime]::get_Now().get_Minute().ToString("D2"))</VersionSuffix>
    <VersionSuffix Condition=" '$(ComputerName)' == '' ">$([System.DateTime]::get_Now().get_Year())$([System.DateTime]::get_Now().get_Month().ToString("D2"))$([System.DateTime]::get_Now().get_Day().ToString("D2"))-$([System.DateTime]::get_Now().get_Hour().ToString("D2"))$([System.DateTime]::get_Now().get_Minute().ToString("D2"))</VersionSuffix>
  </PropertyGroup>
```

If you want to see the sort of thing that can be done with MSBuild and versioning I made a sample repository about 4 years ago when I was still primarily working in VB.NET.

[Versioning Demos](https://github.com/smabuk/VersioningDemos)